### PR TITLE
Texture replacements

### DIFF
--- a/plugins/GSdx/DDS.cpp
+++ b/plugins/GSdx/DDS.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include <DDS.h>
 
-DDS::DDSFile DDS::CatchDDS(const char* fileName) {
+DDS::DDSFile DDS::ReadDDS(const char* fileName) {
 	std::fstream binaryIo;
 	char* _headerData = new char[0x80];
 
@@ -15,7 +15,7 @@ DDS::DDSFile DDS::CatchDDS(const char* fileName) {
 
 	if (_header->dwMagic == 0x20534444 && 
 	   (_header->ddspf.dwFlags & 0x40) == 0x40 &&
-		_header->ddspf.dwRGBBitCount == 32 &&
+	    _header->ddspf.dwRGBBitCount == 32 &&
 	   (_header->dwCaps & 0x1000) == 0x1000)
 	{
 		int const _len = _header->dwHeight * _header->dwWidth * 4;
@@ -47,4 +47,43 @@ DDS::DDSFile DDS::CatchDDS(const char* fileName) {
 
 	else
 		return DDSFile();
+}
+
+bool DDS::WriteDDS(const std::string& fileName, uint32 dataSize, uint32 width, uint32 height, const uint8* pixelData) {
+	printf("Writing file %s\n", fileName.c_str());
+
+	std::ofstream _out(fileName, std::ios::binary);
+
+	const int _zero = 0x00;
+	const uint32 _output[] = {0x7C, 0x02100F, height, width, 0x800, 0x01, 0x01};
+	const uint32 _output2[] = {0x20, 0x41, 0x00, 0x20, 0xFF, 0xFF00, 0xFF0000, 0xFF000000, 0x1000};
+
+	std::vector<unsigned char> _imgData;
+	_imgData.resize(dataSize);
+
+	memcpy(_imgData.data(), pixelData, dataSize);
+
+	for (int i = 3; i < dataSize; i += 4)
+	{
+		unsigned char const _factor = 2;
+		int _value = std::min(_imgData.at(i) * _factor, 255);
+
+		_imgData.at(i) = static_cast<unsigned char>(_value);
+	}
+
+	_out << "DDS ";
+	_out.write(reinterpret_cast<const char*>(&_output), 4 * 7);
+
+	for (int o = 0; o < 11; o++)
+		_out.write(reinterpret_cast<const char*>(&_zero), 4);
+
+	_out.write(reinterpret_cast<const char*>(&_output2), 4 * 9);
+
+	for (int o = 0; o < 4; o++)
+		_out.write(reinterpret_cast<const char*>(&_zero), 4);
+	
+	_out.write(reinterpret_cast<const char*>(_imgData.data()), dataSize);
+	_out.close();
+
+	return true;
 }

--- a/plugins/GSdx/DDS.h
+++ b/plugins/GSdx/DDS.h
@@ -41,5 +41,6 @@ namespace DDS
 		std::vector<unsigned char> Data;
 	};
 
-	DDSFile CatchDDS(const char* fileName);
+	DDSFile ReadDDS(const char* fileName);
+	bool WriteDDS(const std::string& fileName, uint32 dataSize, uint32 width, uint32 height, const uint8* pixelData);
 }

--- a/plugins/GSdx/GSdx.cpp
+++ b/plugins/GSdx/GSdx.cpp
@@ -352,9 +352,9 @@ void GSdxApp::Init()
 #else
 	m_default_configuration["osd_fontname"]                               = "/usr/share/fonts/truetype/my_favorite_font_e_g_DejaVu Sans.ttf";
 #endif
-	m_default_configuration["enable_texture_func"]						  = "0";
-	m_default_configuration["dump_textures"]							  = "1";
-	m_default_configuration["replace_textures"]							  = "0";
+	m_default_configuration["enable_texture_func"]                        = "0";
+	m_default_configuration["dump_textures"]                              = "1";
+	m_default_configuration["replace_textures"]                           = "0";
 	m_default_configuration["osd_color_r"]                                = "0";
 	m_default_configuration["osd_color_g"]                                = "160";
 	m_default_configuration["osd_color_b"]                                = "255";

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -1694,7 +1694,7 @@ void GSRendererHW::Draw()
 					if (_fileCaptured) { // If a path is captured;
 						if (_texMap.find(_currentChecksum) == _texMap.end()) { // If the texture is not already parsed;
 							if (stat(_path.c_str(), &_statBuf) == 0) { // If the captured path actually exists;
-								DDS::DDSFile _ddsFile = DDS::CatchDDS(_path.c_str()); // Parse the DDS file in the path.
+								DDS::DDSFile _ddsFile = DDS::ReadDDS(_path.c_str()); // Parse the DDS file in the path.
 
 								if (_ddsFile.Data.size() > 0) { // If we have data from DDS;
 									auto _tex = m_dev->CreateTexture(_ddsFile.Header.dwWidth, _ddsFile.Header.dwHeight); // Create a GSTexture.

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -1810,6 +1810,9 @@ void GSRendererHW::Draw()
 
 									_isReplacing = true; // Signify replacement.
 								}
+								else { // There's a read error with the DDS
+									printf("Error: Replacement DDS texture (%s) of wrong format. Make sure it's DXGI_FORMAT_R8G8B8A8_UNORM.\n", _path.c_str());
+								}
 							}
 						}
 

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -1678,9 +1678,6 @@ void GSRendererHW::Draw()
 				auto const _tmpCRC = crc32(0, Z_NULL, 0);
 				_currentChecksum = crc32(_tmpCRC, _clut.data(), _pLen);
 
-				// Clear the used CLUT data to avoid leaking.
-				_clut.clear();
-
 				if (m_replace_textures) { // If replacing;
 					if (_repTextures.find(_currentChecksum) != _repTextures.end()) { // If a replacement exists for this element;
 						_path.append(_repTextures[_currentChecksum]); // Get the replacement's path.

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -1673,11 +1673,10 @@ void GSRendererHW::Draw()
 										_ddsFile.Data.at(0x03 + i) = _ddsFile.Data.at(0x03 + i) / 2;
 
 									// Update the created GSTexture with the data from the DDS.
-									auto const _data = _ddsFile.Data;
 									auto const _pitch = _ddsFile.Header.dwWidth * 4;
 
 									auto const _rect = GSVector4i(0, 0, _ddsFile.Header.dwWidth, _ddsFile.Header.dwHeight);
-									_tex->Update(_rect, _data.data(), _pitch, 0);
+									_tex->Update(_rect, _ddsFile.Data.data(), _pitch, 0);
 
 									// This part is complicated. Since we fix the textures
 									// that use UV for their size information, we cannot do

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.cpp
@@ -1810,8 +1810,6 @@ void GSRendererHW::Draw()
 
 									_isReplacing = true; // Signify replacement.
 								}
-
-								_ddsFile.Data.clear();
 							}
 						}
 

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -143,12 +143,17 @@ private:
 	template <bool linear> void RoundSpriteOffset();
 
 protected:
+	std::map<uint32_t, std::unique_ptr<GSTexture>> m_texture_map;
+	std::map<uint32_t, std::string> m_replacement_textures;
 	GSTextureCache* m_tc;
 	GSVector4i m_r;
 	GSTextureCache::Source* m_src;
 
 	virtual void DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* tex, GSTexture* inp = nullptr) = 0;
 	int TryParseYaml();
+
+	// Used as a three-way flag. Made to combat the 0x00000000 CRC at the beginning. 
+	int m_yaml_parsed;
 
 	int m_userhacks_round_sprite_offset;
 	int m_userHacks_HPO;

--- a/plugins/GSdx/Renderers/HW/GSRendererHW.h
+++ b/plugins/GSdx/Renderers/HW/GSRendererHW.h
@@ -151,6 +151,7 @@ protected:
 
 	virtual void DrawPrims(GSTexture* rt, GSTexture* ds, GSTextureCache::Source* tex, GSTexture* inp = nullptr) = 0;
 	int TryParseYaml();
+	void TextureHandling(GSTexture* rt, GSTexture* ds);
 
 	// Used as a three-way flag. Made to combat the 0x00000000 CRC at the beginning. 
 	int m_yaml_parsed;

--- a/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
+++ b/plugins/GSdx/Renderers/OpenGL/GSTextureOGL.cpp
@@ -25,6 +25,7 @@
 #include "GSTextureOGL.h"
 #include "GLState.h"
 #include "GSPng.h"
+#include "DDS.h"
 
 #ifdef ENABLE_OGL_DEBUG_MEM_BW
 extern uint64 g_real_texture_upload_byte;
@@ -554,18 +555,17 @@ void GSTextureOGL::CommitPages(const GSVector2i& region, bool commit)
 	GLState::available_vram -= m_mem_usage;
 }
 
-bool GSTextureOGL::SaveDDS(const std::string& fn)
+bool GSTextureOGL::SaveDDS(const std::string& fileName)
 {
 	// Collect the texture data
 	uint32 pitch = 4 * m_committed_size.x;
 	uint32 buf_size = pitch * m_committed_size.y * 2; // Note *2 for security (depth/stencil)
 	std::unique_ptr<uint8[]> image(new uint8[buf_size]);
 
-	if (IsBackbuffer())
+	if (IsBackbuffer()){
 		glReadPixels(0, 0, m_committed_size.x, m_committed_size.y, GL_RGBA, GL_UNSIGNED_BYTE, image.get());
-
-	else if (IsDss())
-	{
+	}
+	else if (IsDss()) {
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, m_fbo_read);
 
 		glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_texture_id, 0);
@@ -573,65 +573,29 @@ bool GSTextureOGL::SaveDDS(const std::string& fn)
 
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 	}
-
-	else if (m_format == GL_R32I)
+	else if (m_format == GL_R32I) {
 		glGetTextureImage(m_texture_id, 0, GL_RED_INTEGER, GL_INT, buf_size, image.get());
-
-	else
-	{
+	}
+	else {
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, m_fbo_read);
 
 		glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture_id, 0);
 
-		if (m_format == GL_RGBA8)
+		if (m_format == GL_RGBA8) {
 			glReadPixels(0, 0, m_committed_size.x, m_committed_size.y, GL_RGBA, GL_UNSIGNED_BYTE, image.get());
-		else if (m_format == GL_R16UI)
+		}
+		else if (m_format == GL_R16UI) {
 			glReadPixels(0, 0, m_committed_size.x, m_committed_size.y, GL_RED_INTEGER, GL_UNSIGNED_SHORT, image.get());
-		else if (m_format == GL_R8)
+		}
+		else if (m_format == GL_R8) {
 			glReadPixels(0, 0, m_committed_size.x, m_committed_size.y, GL_RED, GL_UNSIGNED_BYTE, image.get());
+		}
 
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 	}
 
-	std::ofstream _out(fn, std::ios::binary);
-
-	int _zero = 0x00;
 	int const _dataSize = pitch * m_committed_size.y;
-
-	uint32 _output[] = {0x7C, 0x02100F, static_cast<uint32>(m_committed_size.y), static_cast<uint32>(m_committed_size.x), 0x800, 0x01, 0x01};
-	uint32 _output2[] = {0x20, 0x41, 0x00, 0x20, 0xFF, 0xFF00, 0xFF0000, 0xFF000000, 0x1000};
-
-	std::vector<unsigned char> _imgData;
-	_imgData.resize(_dataSize);
-
-	memcpy(_imgData.data(), image.get(), _dataSize);
-	image.release();
-
-	for (int i = 3; i < _dataSize; i += 4)
-	{
-		unsigned char const _factor = 2;
-		int _value = std::min(_imgData.at(i) * _factor, 255);
-
-		_imgData.at(i) = static_cast<unsigned char>(_value);
-	}
-
-	_out << "DDS ";
-	_out.write(reinterpret_cast<char*>(&_output), 4 * 7);
-
-	for (int o = 0; o < 11; o++)
-		_out.write(reinterpret_cast<char*>(&_zero), 4);
-
-	_out.write(reinterpret_cast<char*>(&_output2), 4 * 9);
-
-	for (int o = 0; o < 4; o++)
-		_out.write(reinterpret_cast<char*>(&_zero), 4);
-
-	_out.write(reinterpret_cast<char*>(_imgData.data()), pitch * m_committed_size.y);
-	_out.close();
-
-	_imgData.clear();
-
-	return true;
+	return DDS::WriteDDS(fileName, _dataSize, m_committed_size.x, m_committed_size.y, image.get());
 }
 
 bool GSTextureOGL::Save(const std::string& fn)


### PR DESCRIPTION
Hi there, as I said, I was wanting to help push this along, so I've done some review over the current code and adjustments that I think will be beneficial:

- Added an error for when a DDS file we try to Read fails. We'll now print the name of the failed texture. Unfortunately this will now print to the console every frame due to us not storing that we've already checked failed replacements. But I think this is actually better than nothing. That said, I can address this issue in this PR before if you think it prudent.
- Unified the similar code in SaveDDS for both GL and DX backends by adding a WriteDDS.
- Renamed CatchDDS to ReadDDS to clarify the use of the function.
- Renamed most variables to match the style I see in the surrounding code, as well as making some of them slightly more verbose to ease reading.
- Adjusted some comments that were a bit too informal.
- Added detail to some comments where I felt I had a firm grasp, and the existing comment hadn't quite hit the mark.
- Moved the globals in the GSRendererHW.cpp file into the GSRendererHW class.
- Moved the TextureHandling code from GSRendererHW.cpp into it's own function to start easing that code into it's own space. I think more work could be done here, such as separating texture dumping from texture replacement, but I wanted to start with this.
- Fixed a memory leak due to calling std::unique_ptr::release in GSTextureOGL::SaveDDS
- Added a comment explaining an issue with the CLUT hash calculation that could persist when changing to another hash function. In a couple days I'll have more games in to test, but as explained in the comment, the current one I'm testing crashed early with the fix, so out of caution I'm leaving it as it is.

I still want to do more in further PRs, as I said I'd like to integrate PNG back in as an option and investigate the perf issues you mentioned. I'm primarily concerned with this feature for export and for testing a pack before compressing to a final distribution format. I've got some ideas for potentially mitigating perf issues with each of these, but I need to do perf measurements first to understand the impact.

I also mentioned basis texture compression. Unfortunately this is apache 2, which as you stated in the thread, is not formally accepted as compatible with GPL2, so unless the devs are willing to accept that, I will likely instead investigate some of the compressed DDS internal formats.